### PR TITLE
"dugga" to "duggga"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2460,7 +2460,7 @@
                                                 ggg</td>
                                             <td class="border border-gray-300 dark:border-gray-600 px-4 py-3">গ্গ</td>
                                             <td class="border border-gray-300 dark:border-gray-600 px-4 py-3 font-mono">
-                                                dugga → দুগ্গা</td>
+                                                duggga → দুগ্গা</td>
                                         </tr>
                                         <tr class="hover:bg-gray-100 dark:hover:bg-gray-600">
                                             <td class="border border-gray-300 dark:border-gray-600 px-4 py-3 font-mono">


### PR DESCRIPTION

<img width="800" height="1049" alt="Screenshot_২০২৫০৮২৮-০২৪৬৫৭~2" src="https://github.com/user-attachments/assets/6ab7dc61-a5a5-4d26-b9bd-ee8688d0bb2a" />
In section "ক্ষিপ্র ম্যাপিংয়ের পূর্ণাঙ্গ সারণী", when we're talking about "ggg", in an example we used "dugga". But as rule, "dugga" comes "দুজ্ঞা". We need to use an extra "g" like "duggga" to get output "দুগ্গা".